### PR TITLE
Update ParalyzeM to use a struct instead of map

### DIFF
--- a/paralyze.go
+++ b/paralyze.go
@@ -43,9 +43,14 @@ func Paralyze(funcs ...Paralyzable) (results []interface{}, errors []error) {
 	return results, errors
 }
 
+type ResErr struct {
+	Res interface{}
+	Err error
+}
+
 // ParalyzeM parallelizes a map of strings to functions. The return type is a
 // map of keys to a map containing two keys: res and err.
-func ParalyzeM(m map[string]Paralyzable) map[string]map[string]interface{} {
+func ParalyzeM(m map[string]Paralyzable) map[string]ResErr {
 	var names []string
 	var fns []Paralyzable
 
@@ -54,13 +59,14 @@ func ParalyzeM(m map[string]Paralyzable) map[string]map[string]interface{} {
 		fns = append(fns, fn)
 	}
 
-	res := make(map[string]map[string]interface{})
+	res := make(map[string]ResErr)
 	results, errs := Paralyze(fns...)
 	for i := range results {
 		name := names[i]
-		res[name] = make(map[string]interface{})
-		res[name]["res"] = results[i]
-		res[name]["err"] = errs[i]
+		res[name] = ResErr{
+			Res: results[i],
+			Err: errs[i],
+		}
 	}
 
 	return res

--- a/paralyze_test.go
+++ b/paralyze_test.go
@@ -84,10 +84,10 @@ func TestParalyzeM(t *testing.T) {
 		},
 	})
 
-	assert.Equal(t, "foo", results["foo"]["res"], "foo")
-	assert.Nil(t, results["foo"]["err"])
-	assert.Nil(t, results["err"]["res"])
-	assert.Equal(t, errBadThing, results["err"]["err"])
+	assert.Equal(t, "foo", results["foo"].Res, "foo")
+	assert.Nil(t, results["foo"].Err)
+	assert.Nil(t, results["err"].Res)
+	assert.Equal(t, errBadThing, results["err"].Err)
 }
 
 func fnCreator(wait time.Duration) ParalyzableCtx {


### PR DESCRIPTION
Improve function signature for ParalyzeM
