### PR TITLE
Add paralyze with limited concurrency

### DIFF
--- a/paralyze_test.go
+++ b/paralyze_test.go
@@ -111,3 +111,21 @@ func TestParalyzePanic(t *testing.T) {
 		)
 	})
 }
+
+func TestParalyzeLimit(t *testing.T) {
+	results, errs := ParalyzeLimit(2, slowFn, fastFn, errFn)
+
+	// Make sure both slices returned are the correct length
+	assert.Equal(t, 3, len(results))
+	assert.Equal(t, 3, len(errs))
+
+	// Assert that return values are in the correct order
+	assert.Equal(t, "ok", results[0])
+	assert.Equal(t, 55, results[1])
+	assert.Nil(t, results[2])
+
+	// Assert that errors are
+	assert.Nil(t, errs[0])
+	assert.Nil(t, errs[1])
+	assert.Equal(t, someError, errs[2])
+}


### PR DESCRIPTION
This PR adds a `ParalyzeLimit` function that lets you specify max concurrency for a list of parallelizable tasks.