### PR TITLE
Refactor static methods around Paralyzer struct and expose Options

### DIFF
--- a/paralyze_test.go
+++ b/paralyze_test.go
@@ -13,9 +13,10 @@ import (
 var (
 	someError = errors.New("some error")
 
-	slowFn = func() (interface{}, error) { time.Sleep(time.Second); return "ok", nil }
-	fastFn = func() (interface{}, error) { return 55, nil }
-	errFn  = func() (interface{}, error) { return nil, someError }
+	slowFn  = func() (interface{}, error) { time.Sleep(time.Second); return "ok", nil }
+	fastFn  = func() (interface{}, error) { return 55, nil }
+	errFn   = func() (interface{}, error) { return nil, someError }
+	panicFn = func() (interface{}, error) { panic("whoops") }
 )
 
 func TestParalyze(t *testing.T) {
@@ -49,9 +50,54 @@ func TestParalyzeWithTimeout(t *testing.T) {
 	assert.Nil(t, results[2])
 
 	// Assert that errors are
-	assert.Error(t, errs[0])
+	assert.Equal(t, ErrTimedOut, errs[0])
 	assert.Nil(t, errs[1])
 	assert.Equal(t, someError, errs[2])
+}
+
+func TestParalyzeWithZeroTimeout(t *testing.T) {
+	results, errs := ParalyzeWithTimeout(0, slowFn, fastFn, errFn)
+
+	// Make sure both slices returned are the correct length
+	assert.Equal(t, 3, len(results))
+	assert.Equal(t, 3, len(errs))
+
+	// Assert that return values are in the correct order
+	assert.Equal(t, "ok", results[0])
+	assert.Equal(t, 55, results[1])
+	assert.Nil(t, results[2])
+
+	// Assert that errors are
+	assert.Nil(t, errs[0])
+	assert.Nil(t, errs[1])
+	assert.Equal(t, someError, errs[2])
+}
+
+func TestParalyzeWithCancel(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-time.After(time.Millisecond):
+			done <- struct{}{}
+		}
+	}()
+
+	results, errs := ParalyzeWithCancel(done, slowFn, fastFn, errFn)
+
+	// Make sure both slices returned are the correct length
+	assert.Equal(t, 3, len(results))
+	assert.Equal(t, 3, len(errs))
+
+	// Assert that return values are in the correct order
+	assert.Nil(t, results[0])
+	assert.Equal(t, 55, results[1])
+	assert.Nil(t, results[2])
+
+	// Assert that errors are
+	assert.Equal(t, ErrCanceled, errs[0])
+	assert.Nil(t, errs[1])
+	assert.Equal(t, someError, errs[2])
+
 }
 
 func TestParalyzeWithCtx(t *testing.T) {
@@ -103,12 +149,7 @@ func fnCreator(wait time.Duration) ParalyzableCtx {
 
 func TestParalyzePanic(t *testing.T) {
 	assert.Panics(t, func() {
-		Paralyze(
-			func() (interface{}, error) {
-				panic("whoops")
-				return nil, nil
-			},
-		)
+		Paralyze(panicFn)
 	})
 }
 


### PR DESCRIPTION
Hey Ian,
I've attempted a fairly large refactor of this library with the hope that future features will be available to all methods (and be composable). Would love some feedback on whether you think this is the correct interface and am happy to make any changes you recommend.
-Jonah

---

This change refactors existing Paralyzer functions into a single
`Paralyzer.DoContext` method which can take multiple options. The primary motivation
for this change is being able to use a combination of `ParalyzeWithLimit` and
`ParalyzeWithCancel` without passing a cancellation context into each
Paralyzable function. This new functionality is exposed as:

```go
NewParalyzer(WithConcurrencyLimit(32)).DoContext(ctx, funcs...)
```

The intention of the Options abstraction is so that new core functionality can
be exposed there and added to the `DoContext` method; however, this might not
be the correct interface for things like speculative execution.

Additionally, this PR makes the assumption that partial results and errors
will *not* be consumed if the Paralyzer panics and the caller recovers.